### PR TITLE
[Feature] Kafka 기본 설정 추가

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'io.projectreactor:reactor-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/config/KafkaProducerConfig.java
+++ b/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package openvirtualbank.site.gateway.global.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/config/KafkaProducerConfig.java
+++ b/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/config/KafkaProducerConfig.java
@@ -16,10 +16,10 @@ public class KafkaProducerConfig {
     @Bean
     public ProducerFactory<String, String> producerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); //todo 배포시 배포 주소로 변경
         config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.ACKS_CONFIG, "all"); // 브로커에서 메세지를 받고 그 메세지를 페일오버까지 받았을 경우 ack 수신 -> 안정성이 가장 높음
         config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         return new DefaultKafkaProducerFactory<>(config);
     }

--- a/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/service/KafkaProducerService.java
+++ b/gateway/src/main/java/openvirtualbank/site/gateway/global/kafka/service/KafkaProducerService.java
@@ -1,0 +1,27 @@
+package openvirtualbank.site.gateway.global.kafka.service;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public Mono<String> sendMessage(String topic, String key, String message, String returnMessage) {
+        CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(topic, key, message);
+
+        return Mono.fromFuture(future)
+                .map(result -> returnMessage) // 컨트롤러 별로 사용자 응답을 다르게 설정하기 위함
+                .onErrorResume(e -> Mono.error(new KafkaException("카프카 메세지 전송 실패", e)));
+    }
+
+    //todo 규진이형이 만든 GlobalExceptionHandler에 KafkaException 추가
+}
+


### PR DESCRIPTION
## 🔧 PR 종류 (하나만 선택해주세요)
- [ ] 기능 개선 (기존 기능의 동작/성능 향상)
- [ ] 새로운 기능 추가 (신규 도메인, 기능 등)
- [ ] 리팩토링 (동작 변경 없음, 구조 개선)
- [ ] 문서 수정 (README, API 문서 등)
- [ ] 테스트 추가 / 수정
- [X] 인프라 구성 변경 (Kafka, AWS 리소스 등)
- [ ] 기타

---

## 📦 변경된 모듈 (복수 선택 가능)

[gateway]

---

## ✨ 주요 변경 사항

- 어떤 기능이 추가되었고, 어떤 이슈/버그가 해결되었는지 간결하고 명확하게 설명해주세요.

> - Kafka 기본 설정 추가
> - lombok 의존성 추가

---

## 📝 상세 설명

- 카프카의 기본 설정을 추가했습니다. return 메세지를 받도록하여 컨트롤러 별로 사용자에게 반환하는 메세지를 동적으로 반환할 수 있게 구성하였습니다.
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/7e519097-0202-44f3-986f-32a8117d9460" />

- 카프카 테스트 -> 간단하게 요청을 보낸 후 해당 요청이 카프카 컨슈머에 잘 도착하는지 확인하는 테스트를 진행해봤습니다.
- 1212를 메세지 파트에 담아 보낸 결과 1212가 컨슈머에 잘 보이는 것을 확인할 수 있었습니다.
![image](https://github.com/user-attachments/assets/75332b96-63b5-4ad3-8165-f124a399ad9a)



---

## 📣 기타 공유할 내용

- 리뷰어가 알면 좋을 만한 정보나, 추가 설명이 필요한 부분이 있다면 작성해주세요.
